### PR TITLE
Explicitly set directory permissions on $NODENV_ROOT/versions

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,6 +32,7 @@ class nodejs(
   file { "${nodejs::nodenv_root}/versions":
     ensure  => directory,
     owner   => $nodenv_user,
+    mode    => '0755',
     require => Repository[$nodenv_root]
   }
 }


### PR DESCRIPTION
In environments where File resource defaults are locked down, the $NODENV_ROOT/versions directory may be locked down. This might cause issues when using `nodenv` globally versus per-user.

This change explicitly sets directory permissions that allow world read/execute.
