### PR TITLE
Add module to install a nodenv plugin.

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -1,0 +1,19 @@
+# Public: Install an nodenv plugin.
+#
+# Usage:
+#
+#       nodejs::plugin { 'nodenv-vars':
+#         ensure => 'v0.1.0',
+#         source => 'johnbellone/nodenv-vars'
+#       }
+
+define nodejs::plugin($ensure, $source) {
+  include nodejs
+
+  repository { "${nodejs::nodenv_root}/plugins/${name}":
+    ensure => $ensure,
+    force  => true,
+    source => $source,
+    user   => $nodejs::user
+  }
+}

--- a/spec/defines/nodejs__plugin_spec.rb
+++ b/spec/defines/nodejs__plugin_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe 'nodejs::plugin' do
+  let(:facts) { default_test_facts }
+
+  let(:title) { 'nodenv-vars' }
+
+  let(:params) do
+    { :ensure => 'present', :source => 'johnbellone/nodenv-vars' }
+  end
+
+  it do
+    should include_class('nodejs')
+
+    should contain_repository('/test/boxen/nodenv/plugins/nodenv-vars').with({
+      :ensure => 'present',
+      :source => 'johnbellone/nodenv-vars'
+    })
+  end
+end


### PR DESCRIPTION
Exactly how this is available in puppet-rbenv we need capability of installing a plugin.