### PR TITLE
Fix local path to node_modules.

### DIFF
--- a/files/nodenv.sh
+++ b/files/nodenv.sh
@@ -6,5 +6,5 @@ export PATH=$BOXEN_HOME/nodenv/bin:$PATH
 
 eval "$(nodenv init -)"
 
-export PATH=node_modules/.bin:$PATH
+export PATH=./node_modules/.bin:$PATH
 


### PR DESCRIPTION
Fixes local node_modules path. Feature and bug introduced here https://github.com/boxen/puppet-nodejs/pull/19. Slight security risk because you can probably install malware via npm. Imagine a nefarious module that could install a binary called `ls` that now appeared in your PATH before its usual place in /bin.