### PR TITLE
Fix npm_module install

### DIFF
--- a/lib/puppet/provider/npm_module/npm.rb
+++ b/lib/puppet/provider/npm_module/npm.rb
@@ -146,7 +146,7 @@ private
     bindir = "/opt/nodes/#{node_version}/bin"
     execute "#{bindir}/npm #{command} --global", {
       :combine            => true,
-      :uid                => user,
+      :user                => user,
       #Npm versions greater than 0.10.26 return 1 when no dependencies are returned
       :failonfail         => failonfail,
       :override_locale    => false,
@@ -163,7 +163,7 @@ private
     bindir = "/opt/nodes/#{node_version}/bin"
     execute "#{bindir}/npm list --global --json --depth=0 --silent", {
       :combine            => true,
-      :uid                => user,
+      :user                => user,
       #Npm versions greater than 0.10.26 return 1 when no dependencies are returned
       :failonfail         => false,
       :override_locale    => false,


### PR DESCRIPTION
I can't install npm modules. it's fix bugs.
because pupet exec params miss.

bug report.

```ruby
  $version = "0.12"
(snip)
  npm_module { 'grunt-cli for ${version}':
    module       => 'grunt-cli',
    node_version => $version,
  }
```
errors
```
npm ERR! argv "node" "/opt/nodes/0.12/bin/npm" "install" "grunt-cli@>= 0" "--global"
npm ERR! node v0.12.7
npm ERR! npm  v2.14.0
npm ERR! path /Users/root
npm ERR! code EACCES
npm ERR! errno -13

npm ERR! Error: EACCES, mkdir '/Users/root'
npm ERR!     at Error (native)
npm ERR!  { [Error: EACCES, mkdir '/Users/root'] errno: -13, code: 'EACCES', path: '/Users/root' }
npm ERR!
npm ERR! Please try running this command again as root/Administrator.
```
