### PR TITLE
Fixes nodejs.sh

### DIFF
--- a/templates/nodejs.sh
+++ b/templates/nodejs.sh
@@ -8,7 +8,9 @@ export PATH=$NODENV_ROOT/bin:$PATH
 # Load nodenv
 eval "$(nodenv init -)"
 
+export PATH=./node_modules/.bin:$PATH
+
 # Helper for shell prompts and the like
 current_node() {
-  echo "$(nodenv version-name)"
+  echo "$(nodenv version)"
 }


### PR DESCRIPTION
+ `nodenv version-name` isn't a function
+ the rewrite clobbered the local `.node_modules/bin` path addition