### PR TITLE
Fish Compatibility

### DIFF
--- a/files/nodenv.fish
+++ b/files/nodenv.fish
@@ -4,6 +4,6 @@ set -gx NODENV_ROOT $BOXEN_HOME/nodenv
 
 set -gx PATH $BOXEN_HOME/nodenv/bin $PATH
 
-eval (nodenv init -)
+source (nodenv init - | psub)
 
 set -gx PATH ./node_modules/.bin $PATH

--- a/files/nodenv.fish
+++ b/files/nodenv.fish
@@ -1,0 +1,9 @@
+# Configure and activate nodenv. You know, for nodes.
+
+set -gx NODENV_ROOT $BOXEN_HOME/nodenv
+
+set -gx PATH $BOXEN_HOME/nodenv/bin $PATH
+
+eval (nodenv init -)
+
+set -gx PATH ./node_modules/.bin $PATH

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,7 +18,7 @@ class nodejs(
 
   if $::osfamily == 'Darwin' {
     boxen::env_script { 'nodejs-fish':
-      content  => template('nodejs/nodejs.fish'),
+      content  => template('nodejs/nodejs.fish.erb'),
       priority => 'higher',
     }
     boxen::env_script { 'nodejs':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,8 +18,9 @@ class nodejs(
 
   if $::osfamily == 'Darwin' {
     boxen::env_script { 'nodejs-fish':
-      content  => template('nodejs/nodejs.fish.erb'),
-      priority => 'higher',
+      content   => template('nodejs/nodejs.fish.erb'),
+      priority  => 'higher',
+      extension => 'fish',
     }
     boxen::env_script { 'nodejs':
       content  => template('nodejs/nodejs.sh'),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,9 +18,10 @@ class nodejs(
 
   if $::osfamily == 'Darwin' {
     boxen::env_script { 'nodejs-fish':
-      content   => template('nodejs/nodejs.fish.erb'),
-      priority  => 'higher',
-      extension => 'fish',
+      content    => template('nodejs/nodejs.fish.erb'),
+      priority   => 'higher',
+      scriptname => 'nodejs',
+      extension  => 'fish',
     }
     boxen::env_script { 'nodejs':
       content  => template('nodejs/nodejs.sh'),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,6 +17,10 @@ class nodejs(
   include $provider_class
 
   if $::osfamily == 'Darwin' {
+    boxen::env_script { 'nodejs-fish':
+      content  => template('nodejs/nodejs.fish'),
+      priority => 'higher',
+    }
     boxen::env_script { 'nodejs':
       content  => template('nodejs/nodejs.sh'),
       priority => 'higher',

--- a/templates/nodejs.fish.erb
+++ b/templates/nodejs.fish.erb
@@ -6,7 +6,7 @@ set -gx NODENV_ROOT <%= scope.lookupvar("::nodejs::nodenv::prefix") %>
 set -gx PATH $NODENV_ROOT/bin $PATH
 
 # Load nodenv
-eval "$(nodenv init -)"
+eval (nodenv init -)
 
 set -gx PATH ./node_modules/.bin $PATH
 

--- a/templates/nodejs.fish.erb
+++ b/templates/nodejs.fish.erb
@@ -6,7 +6,7 @@ set -gx NODENV_ROOT <%= scope.lookupvar("::nodejs::nodenv::prefix") %>
 set -gx PATH $NODENV_ROOT/bin $PATH
 
 # Load nodenv
-eval (nodenv init -)
+source (nodenv init - | psub)
 
 set -gx PATH ./node_modules/.bin $PATH
 

--- a/templates/nodejs.fish.erb
+++ b/templates/nodejs.fish.erb
@@ -1,0 +1,16 @@
+# Put node-build on PATH
+set -gx PATH <%= scope.lookupvar("::nodejs::build::prefix") %>/bin $PATH
+
+# Configure NODENV_ROOT and put NODENV_ROOT/bin on PATH
+set -gx NODENV_ROOT <%= scope.lookupvar("::nodejs::nodenv::prefix") %>
+set -gx PATH $NODENV_ROOT/bin $PATH
+
+# Load nodenv
+eval "$(nodenv init -)"
+
+set -gx PATH ./node_modules/.bin $PATH
+
+# Helper for shell prompts and the like
+function current_node
+  nodenv version
+end


### PR DESCRIPTION
Adds a Fish version of the env script. 

Relies on boxen/puppet-boxen#138 (for the `extension` argument to `env_script`).

`nodenv init -` won't work properly with the latest released version of nodenv; you'll have to `cd /opt/boxen/nodenv; and git fetch origin; and git reset --hard origin/master` to get Fish compatibility from the HEAD of nodenv. Sorry, I didn't see a way to tell puppet to get HEAD rather than a tagged release.
