### PR TITLE
Use nodenv version-name in shell helper function

### DIFF
--- a/templates/nodejs.sh
+++ b/templates/nodejs.sh
@@ -12,5 +12,5 @@ export PATH=./node_modules/.bin:$PATH
 
 # Helper for shell prompts and the like
 current_node() {
-  echo "$(nodenv version)"
+  echo "$(nodenv version-name)"
 }


### PR DESCRIPTION
`nodenv version` includes a description of how the version was selected:

    $ nodenv version
    5.0.0 (set by /opt/boxen/nodenv/version)

`nodenv version-name` prints the version number on its own:

    $ nodenv version-name
    5.0.0

Since the `current_node` function is intended to be used "in shell prompts and the like", the second shorter form is more appropriate.

This reverts the change from #56, which had the description:

> `nodenv version-name` isn't a function

It is, though; defined here: https://github.com/OiNutter/nodenv/blob/master/libexec/nodenv-version-name

I suspect @DanielWright was stuck using [wfarr/nodenv](https://github.com/wfarr/nodenv), which doesn't provide `nodenv version-name`: https://github.com/wfarr/nodenv/tree/master/libexec

...and I suspect _that_ happened because of a bug in [boxen/puppet-repository](https://github.com/boxen/puppet-repository), which meant refs weren't updated when the remote was changed: https://github.com/boxen/puppet-repository/pull/16