### PR TITLE
remove relative node_modules .bin from PATH

### DIFF
--- a/templates/nodejs.sh
+++ b/templates/nodejs.sh
@@ -8,8 +8,6 @@ export PATH=$NODENV_ROOT/bin:$PATH
 # Load nodenv
 eval "$(nodenv init -)"
 
-export PATH=./node_modules/.bin:$PATH
-
 # Helper for shell prompts and the like
 current_node() {
   echo "$(nodenv version-name)"


### PR DESCRIPTION
Having './node_modules/.bin' on the PATH breaks react-native and causes other NPM modules to be confused as to where they are installed (ie. phantomjs). Maybe it's best to leave this decision to the user instead of having it as default. This is not really boxen-specific behaviour anyway and is not needed to run nodejs via boxen.