### PR TITLE
Bumped version of node-build to 2.3.5

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -20,7 +20,7 @@ nodejs::prefix: '/opt'
 nodejs::provider: 'nodenv'
 nodejs::user: "%{::id}"
 
-nodejs::build::ensure: v2.2.7
+nodejs::build::ensure: v2.3.4
 nodejs::build::prefix: "%{hiera('nodejs::prefix')}/node-build"
 nodejs::build::user: "%{hiera('nodejs::user')}"
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -20,7 +20,7 @@ nodejs::prefix: '/opt'
 nodejs::provider: 'nodenv'
 nodejs::user: "%{::id}"
 
-nodejs::build::ensure: v2.3.4
+nodejs::build::ensure: v2.3.5
 nodejs::build::prefix: "%{hiera('nodejs::prefix')}/node-build"
 nodejs::build::user: "%{hiera('nodejs::user')}"
 


### PR DESCRIPTION
Version bump is required to add support for node 6.x versions.