### PR TITLE
Fix for file ownership issues

### DIFF
--- a/lib/puppet/provider/npm_module/npm.rb
+++ b/lib/puppet/provider/npm_module/npm.rb
@@ -146,7 +146,7 @@ private
     bindir = "/opt/nodes/#{node_version}/bin"
     execute "#{bindir}/npm #{command} --global", {
       :combine            => true,
-      :user                => user,
+      :uid                => user,
       #Npm versions greater than 0.10.26 return 1 when no dependencies are returned
       :failonfail         => failonfail,
       :override_locale    => false,
@@ -163,7 +163,7 @@ private
     bindir = "/opt/nodes/#{node_version}/bin"
     execute "#{bindir}/npm list --global --json --depth=0 --silent", {
       :combine            => true,
-      :user                => user,
+      :uid                => user,
       #Npm versions greater than 0.10.26 return 1 when no dependencies are returned
       :failonfail         => false,
       :override_locale    => false,


### PR DESCRIPTION
`user` is an option that gets ignored by puppet. `uid` is meant to be
used in order to set a user to execute the command. I cannot find a 
point at which it ever was `user` in recent, not so recent and far distant 
versions of puppet which leads me to believe this change was 
introduced by accident.

The effect of using `user` vs `uid` are shown below:

```
▶ ls -l `npm config get prefix`/lib/node_modules
total 0
drwxr-xr-x  12 hugobastien  staff  408 14 Nov 22:37 gulp-cli
drwxr-xr-x  25 hugobastien  staff  850 11 Nov 13:18 npm
drwxr-xr-x   6 nobody       staff  204 14 Nov 22:09 react-native-cli
```

gulp-cli was installed with the fix that I'm submitting here while
react-native-cli was installed current version of puppet-nodejs